### PR TITLE
added options

### DIFF
--- a/bin/puppy.js
+++ b/bin/puppy.js
@@ -49,6 +49,14 @@ const puppyConfig = require('../puppy.config.js')
   const INDEX_FILE = arguments['index-file'] || puppyConfig['indexFile']
   const STATIC_DIR = arguments['static-dir'] || puppyConfig['staticDir']
 
+  const DEVTOOLS = arguments['devtools'] || puppyConfig['devtools']
+
+  const WINDOW_WIDTH = puppyConfig['windowWidth']
+  const WINDOW_HEIGHT = puppyConfig['windowHeight']
+
+  const VIEWPORT_WIDTH = puppyConfig['viewportWidth']
+  const VIEWPORT_HEIGHT = puppyConfig['viewportHeight']
+
   console.log(chalk.cyan(logo(arguments.headless)))
 
   let server
@@ -56,6 +64,25 @@ const puppyConfig = require('../puppy.config.js')
   mkdirp.sync(path.join(process.cwd(), '.puppy'))
   if (fs.existsSync(path.join(process.cwd(), '.puppy') + '/internal-port')) {
     INTERNAL_PORT = fs.readFileSync(path.join(process.cwd(), '.puppy') + '/internal-port')
+  }
+
+  let ENV = {
+    WS,
+    API,
+    PORT,
+    WS_PORT,
+    API_PORT,
+    INTERNAL_PORT,
+    VERBOSE,
+    HEADLESS,
+    WS_URL,
+    INDEX_FILE,
+    STATIC_DIR,
+    DEVTOOLS,
+    WINDOW_WIDTH,
+    WINDOW_HEIGHT,
+    VIEWPORT_WIDTH,
+    VIEWPORT_HEIGHT
   }
 
   try {
@@ -85,7 +112,7 @@ const puppyConfig = require('../puppy.config.js')
     const serverOptions = {
       pwd: process.cwd(),
       stdio: 'pipe',
-      env: Object.assign({}, process.env, {WS, API, PORT, WS_PORT, API_PORT, INTERNAL_PORT, VERBOSE, HEADLESS, WS_URL, INDEX_FILE, STATIC_DIR})
+      env: Object.assign({}, process.env, ENV)
     }
 
     server = spawn(`node`, serverArguments, serverOptions)
@@ -102,7 +129,7 @@ const puppyConfig = require('../puppy.config.js')
 
   const jestOptions = {
     stdio: 'pipe',
-    env: Object.assign({}, process.env, {WS, API, PORT, WS_PORT, API_PORT, INTERNAL_PORT, VERBOSE, HEADLESS, WS_URL, INDEX_FILE, STATIC_DIR})
+    env: Object.assign({}, process.env, ENV)
   }
 
   const jest = spawn('jest', jestArguments, jestOptions)

--- a/config/setup.js
+++ b/config/setup.js
@@ -7,8 +7,8 @@ const puppeteer = require('puppeteer')
 const DIR = path.join(os.tmpdir(), 'jest_puppeteer_global_setup')
 
 module.exports = async function () {
-  const width = 1920
-  const height = 1080
+  const width = process.env.WINDOW_WIDTH
+  const height = process.env.WINDOW_HEIGHT
 
   const browser = await puppeteer.launch({
     headless: process.env.HEADLESS === 'true',
@@ -17,7 +17,7 @@ module.exports = async function () {
       '--disable-setuid-sandbox',
       `--window-size=${width},${height}`,
     ],
-    devtools: process.env.HEADLESS !== 'true'
+    devtools: process.env.HEADLESS !== 'true' && process.env.DEVTOOLS === 'true'
   })
 
   global.__BROWSER__ = browser

--- a/puppy.config.js
+++ b/puppy.config.js
@@ -14,4 +14,10 @@ module.exports = {
   wsUrl: '/ws',
   indexFile: 'index.html',
   staticDir: path.resolve(process.cwd(), 'dist'),
+
+  devtools: true,
+  windowWidth: 1920,
+  windowHeight: 1080,
+  viewportWidth: 1300,
+  viewportHeight: 1080
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -16,7 +16,7 @@ async function register (request) {
 async function newPage (url = '') {
   const page = await this.newPage()
 
-  await page.setViewport({width: 1300, height: 1080})
+  await page.setViewport({width: parseInt(process.env.VIEWPORT_WIDTH), height: parseInt(process.env.VIEWPORT_HEIGHT)})
 
   let isURL
   try {


### PR DESCRIPTION
Options added to `puppy.config.js` - see **NEW**

```
const path = require('path')

module.exports = {
  ws: path.resolve(process.cwd(), 'puppy.ws.js'),
  api: path.resolve(process.cwd(), 'puppy.api.js'),

  port: 8080,
  wsPort: 8080,
  apiPort: 8080,

  verbose: false,
  headless: false,

  wsUrl: '/ws',
  indexFile: 'index.html',
  staticDir: path.resolve(process.cwd(), 'dist'),

  devtools: true, // NEW
  windowWidth: 1920, // NEW
  windowHeight: 1080, // NEW
  viewportWidth: 1300, // NEW
  viewportHeight: 1080 // NEW
}
```

Viewport and Window options **cannot** be configured as command line arguments. On the other hand there is a **devtools** command line argument available

Example

`puppy test --devtools false`